### PR TITLE
New loader of texturepacks with legacy support

### DIFF
--- a/TexWizard.vcxproj.user
+++ b/TexWizard.vcxproj.user
@@ -31,8 +31,10 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_UG2|Win32'">
-    <LocalDebuggerCommand>G:\Games\Need for Speed Underground 2\SPEED2.EXE</LocalDebuggerCommand>
-    <LocalDebuggerWorkingDirectory>G:\Games\Need for Speed Underground 2</LocalDebuggerWorkingDirectory>
+    <LocalDebuggerCommand>
+    </LocalDebuggerCommand>
+    <LocalDebuggerWorkingDirectory>
+    </LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_UG|Win32'">


### PR DESCRIPTION
Textures can be loaded with just moving .bin and .json (example ug2.json and ug2.bin) to TexturePacks folder inside Scripts.